### PR TITLE
Refactor Stage Data Struct Names and Remove Joint Data from Workstation

### DIFF
--- a/worm_picker_core/include/worm_picker_core/tasks/task_data_structure.hpp
+++ b/worm_picker_core/include/worm_picker_core/tasks/task_data_structure.hpp
@@ -20,7 +20,7 @@
  * @enum StageType
  * @brief Enumerates the types of stages available.
  */
-enum class StageType { MOVE_TO, JOINT };
+enum class StageType { MOVE_TO_POINT, MOVE_TO_JOINT };
 
 /** 
  * @struct StageData
@@ -37,10 +37,10 @@ struct StageData {
 };
 
 /** 
- * @struct MoveToData
- * @brief Struct representing data for a MoveTo-based stage.
+ * @struct MoveToPointData
+ * @brief Struct representing data for a point MoveTo-based stage.
  */
-struct MoveToData : public StageData { 
+struct MoveToPointData : public StageData { 
     double x, y, z;  // Position coordinates.
     double qx, qy, qz, qw;  // Orientation as a quaternion.
     double velocity_scaling_factor;  // Velocity scaling factor.
@@ -49,10 +49,10 @@ struct MoveToData : public StageData {
     /** 
      * @brief Default constructor.
      */
-    MoveToData() = default;
+    MoveToPointData() = default;
 
     /** 
-     * @brief Constructs a MoveToData with the given parameters.
+     * @brief Constructs a MoveToPointData with the given parameters.
      * @param px Position x-coordinate.
      * @param py Position y-coordinate.
      * @param pz Position z-coordinate.
@@ -63,17 +63,17 @@ struct MoveToData : public StageData {
      * @param velocity_scaling Velocity scaling factor (default: 0.1).
      * @param acceleration_scaling Acceleration scaling factor (default: 0.1).
      */
-    MoveToData(double px, double py, double pz, double ox, double oy, double oz, double ow,
-              double velocity_scaling = 0.1, double acceleration_scaling = 0.1);
+    MoveToPointData(double px, double py, double pz, double ox, double oy, double oz, double ow,
+                    double velocity_scaling = 0.1, double acceleration_scaling = 0.1);
 
-    StageType getType() const override { return StageType::MOVE_TO; }
+    StageType getType() const override { return StageType::MOVE_TO_POINT; }
 };
 
 /** 
- * @struct JointData
- * @brief Struct representing data for a joint-based stage.
+ * @struct MoveToJointData
+ * @brief Struct representing data for a joint MoveTo-based stage.
  */
-struct JointData : public StageData { 
+struct MoveToJointData : public StageData { 
     std::map<std::string, double> joint_positions;  // Map of joint names to their positions (in radians).
     double velocity_scaling_factor;  // Velocity scaling factor.
     double acceleration_scaling_factor;  // Acceleration scaling factor.
@@ -81,10 +81,10 @@ struct JointData : public StageData {
     /** 
      * @brief Default constructor.
      */
-    JointData() = default;
+    MoveToJointData() = default;
 
     /**
-     * @brief Constructs a JointData with the given joint angles and scaling factors.
+     * @brief Constructs a MoveToJointData with the given joint angles and scaling factors.
      * @param joint1 Angle for joint 1 in degrees.
      * @param joint2 Angle for joint 2 in degrees.
      * @param joint3 Angle for joint 3 in degrees.
@@ -94,10 +94,10 @@ struct JointData : public StageData {
      * @param velocity_scaling Velocity scaling factor (default: 0.1).
      * @param acceleration_scaling Acceleration scaling factor (default: 0.1).
      */
-    JointData(double joint1, double joint2, double joint3, double joint4, double joint5, double joint6,
-              double velocity_scaling = 0.1, double acceleration_scaling = 0.1);
+    MoveToJointData(double joint1, double joint2, double joint3, double joint4, double joint5, double joint6,
+                    double velocity_scaling = 0.1, double acceleration_scaling = 0.1);
 
-    StageType getType() const override { return StageType::JOINT; }
+    StageType getType() const override { return StageType::MOVE_TO_JOINT; }
 };
 
 /** 

--- a/worm_picker_core/include/worm_picker_core/tasks/task_factory.hpp
+++ b/worm_picker_core/include/worm_picker_core/tasks/task_factory.hpp
@@ -55,22 +55,22 @@ private:
     void setupPlanningScene();
 
     /**
-     * @brief Adds a joint move stage to the task.
+     * @brief Adds a MoveToJoint stage to the task.
      * @param task The MoveIt task to which the stage will be added.
      * @param name The name of the stage.
-     * @param joint_data Shared pointer to the JointData containing joint positions and scaling factors.
+     * @param move_to_joint_data Shared pointer to the MoveToJointData containing joint positions and scaling factors.
      * @throws StageCreationFailedException If the stage creation fails.
      */
-    void addJointStage(moveit::task_constructor::Task& task, const std::string& name, const std::shared_ptr<JointData>& joint_data);
+    void addMoveToJointStage(moveit::task_constructor::Task& task, const std::string& name, const std::shared_ptr<MoveToJointData>& move_to_joint_data);
 
     /** 
-     * @brief Adds a MoveTo stage to the task.
+     * @brief Adds a MoveToPoint stage to the task.
      * @param task The MoveIt task to which the stage will be added.
      * @param name The name of the stage.
-     * @param move_to_data Shared pointer to the MoveToData containing pose information and scaling factors.
+     * @param move_to_point_data Shared pointer to the MoveToPointData containing pose information and scaling factors.
      * @throws StageCreationFailedException If the stage creation fails.
      */
-    void addMoveToStage(moveit::task_constructor::Task& task, const std::string& name, const std::shared_ptr<MoveToData>& move_to_data);
+    void addMoveToPointStage(moveit::task_constructor::Task& task, const std::string& name, const std::shared_ptr<MoveToPointData>& move_to_point_data);
     
     // Type aliases
     using Task = moveit::task_constructor::Task;

--- a/worm_picker_core/include/worm_picker_core/tools/parsers/workstation_data_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/tools/parsers/workstation_data_parser.hpp
@@ -14,7 +14,6 @@
 #include <unordered_map>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
-#include <rclcpp/rclcpp.hpp>
 
 /**
  * @brief Represents the coordinate information of a workstation.
@@ -30,23 +29,10 @@ struct Coordinate {
 };
 
 /**
- * @brief Represents the joint positions of a workstation.
- */
-struct Joint {
-    double joint_1; ///< Position of joint 1.
-    double joint_2; ///< Position of joint 2.
-    double joint_3; ///< Position of joint 3.
-    double joint_4; ///< Position of joint 4.
-    double joint_5; ///< Position of joint 5.
-    double joint_6; ///< Position of joint 6.
-};
-
-/**
- * @brief Contains both coordinate and joint data for a workstation.
+ * @brief Contains coordinate data for the workstation.
  */
 struct WorkstationData {
     Coordinate coordinate; ///< Coordinate data of the workstation.
-    Joint joint; ///< Joint data of the workstation.
 };
 
 /**
@@ -60,7 +46,7 @@ public:
      * @param file_path Path to the JSON file.
      * @param node Shared pointer to the ROS2 node.
      */
-    explicit WorkstationDataParser(const std::string& file_path, const rclcpp::Node::SharedPtr& node);
+    explicit WorkstationDataParser(const std::string& file_path);
 
     /**
      * @brief Retrieves the parsed workstation data map.
@@ -74,7 +60,7 @@ private:
      * @param file_path Path to the JSON file.
      * @param node Shared pointer to the ROS2 node.
      */
-    void parseJsonFile(const std::string& file_path, const rclcpp::Node::SharedPtr& node);
+    void parseJsonFile(const std::string& file_path);
 
     /**
      * @brief Checks for invalid values in the JSON data.
@@ -90,20 +76,13 @@ private:
      */
     Coordinate parseCoordinate(const nlohmann::json& coord_json) const;
 
-    /**
-     * @brief Parses the joint data from JSON.
-     * @param joint_json JSON data for joints.
-     * @return Parsed Joint structure.
-     */
-    Joint parseJoint(const nlohmann::json& joint_json) const;
-
     // Type aliases
     using json = nlohmann::json;
     using WorkstationDataMap = std::unordered_map<std::string, WorkstationData>;
 
     static constexpr double INVALID_VALUE = -9999.9;  ///< Invalid value constant.
 
-    WorkstationDataMap workstation_data_map_;  ///< Map of workstation IDs (e.g., "A1") to `WorkstationData` containing Cartesian `Coordinate` and robot `Joint` positions.
+    WorkstationDataMap workstation_data_map_;  ///< Map of workstation IDs (e.g., "A1") to `WorkstationData` containing Cartesian `Coordinate` positions.
 };
 
 #endif // WORKSTATION_DATA_PARSER_HPP

--- a/worm_picker_core/src/tasks/task_data_structure.cpp
+++ b/worm_picker_core/src/tasks/task_data_structure.cpp
@@ -10,7 +10,7 @@
 
 #include "worm_picker_core/tasks/task_data_structure.hpp"
 
-MoveToData::MoveToData(double px, double py, double pz, double ox, double oy, double oz, double ow,
+MoveToPointData::MoveToPointData(double px, double py, double pz, double ox, double oy, double oz, double ow,
                        double velocity_scaling, double acceleration_scaling) 
     : x(px), y(py), z(pz), qx(ox), qy(oy), qz(oz), qw(ow),
       velocity_scaling_factor(velocity_scaling), acceleration_scaling_factor(acceleration_scaling)
@@ -23,7 +23,7 @@ MoveToData::MoveToData(double px, double py, double pz, double ox, double oy, do
     qw = q.w();
 }
 
-JointData::JointData(double joint1, double joint2, double joint3, double joint4, double joint5, double joint6,
+MoveToJointData::MoveToJointData(double joint1, double joint2, double joint3, double joint4, double joint5, double joint6,
                      double velocity_scaling, double acceleration_scaling) 
     : velocity_scaling_factor(velocity_scaling), acceleration_scaling_factor(acceleration_scaling)
 {

--- a/worm_picker_core/src/tasks/task_factory.cpp
+++ b/worm_picker_core/src/tasks/task_factory.cpp
@@ -31,103 +31,104 @@ void TaskFactory::parseData()
 
 void TaskFactory::setupPlanningScene() 
 {
-    auto addPointData = [this](const std::string& name, double x, double y, double z, double qx, double qy, double qz, double qw,
-                               double velocity_scaling = 0.1, double acceleration_scaling = 0.1) {
-        auto point_data = std::make_shared<MoveToData>(x, y, z, qx, qy, qz, qw, velocity_scaling, acceleration_scaling);
-        stage_data_map_[name] = point_data;
+    auto addMoveToPointData = [this](
+        const std::string& name, double x, double y, double z, double qx, double qy, double qz, double qw,
+        double velocity_scaling = 0.1, double acceleration_scaling = 0.1) {
+        auto move_to_point_data = std::make_shared<MoveToPointData>(
+            x, y, z, qx, qy, qz, qw, velocity_scaling, acceleration_scaling);
+        stage_data_map_[name] = move_to_point_data;
     };
 
-    auto addJointData = [this](const std::string& name, double j1, double j2, double j3, double j4, double j5, double j6,
-                               double velocity_scaling = 0.1, double acceleration_scaling = 0.1) {
-        auto joint_data = std::make_shared<JointData>(j1, j2, j3, j4, j5, j6, velocity_scaling, acceleration_scaling);
-        stage_data_map_[name] = joint_data;
+    auto addMoveToJointData = [this](
+        const std::string& name, double j1, double j2, double j3, double j4, double j5, double j6,
+        double velocity_scaling = 0.1, double acceleration_scaling = 0.1) {
+        auto move_to_joint_data = std::make_shared<MoveToJointData>(
+            j1, j2, j3, j4, j5, j6, velocity_scaling, acceleration_scaling);
+        stage_data_map_[name] = move_to_joint_data;
     };
 
-    auto addTaskData = [this](const std::string& name, const std::initializer_list<std::string>& stage_names) {
+    auto addTaskData = [this](
+        const std::string& name, const std::initializer_list<std::string>& stage_names) {
         task_data_map_[name] = TaskData(stage_data_map_, stage_names);
     };
 
-    /*Parameters:*/
-    double hotel_nbr = 1; // currently not working
-    double slot_hotel_nbr = 1;
-    double flat_man_ang = -36.0;
-    double init_arc_hotel = -56.9;
-    double hotel_hotel_ang = 19.4;
-    double base_z = 0.39075;
-    double plate_plate_hotel = 0.026925;
-    double z_disp = (slot_hotel_nbr - 1) * plate_plate_hotel;
-    double arc_hotel_disp = (hotel_nbr - 1) * hotel_hotel_ang;
+    // Parameters:
+    double hotel_number = 1;  // Currently not used
+    double slot_hotel_number = 1;
+    double flat_manipulator_angle = -36.0;
+    double initial_arc_hotel = -56.9;
+    double hotel_to_hotel_angle = 19.4;
+    double base_z_position = 0.39075;
+    double plate_to_plate_hotel = 0.026925;
 
-    /*Test Points&Joints:*/
-    addPointData("homePoint",    0.46200,  0.00000,  0.50500,  0.70711,  0.70711,  0.00000,  0.00000);
-    addPointData("pointA",       0.58638,  0.00000,  0.50499,  0.70711,  0.70711,  0.00000,  0.00000);
-    addJointData("jointS", 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.1);
+    double z_displacement = (slot_hotel_number - 1) * plate_to_plate_hotel;
+    double arc_hotel_displacement = (hotel_number - 1) * hotel_to_hotel_angle;
 
-    /*Configuration Points&Joints:*/
-    // Zeroed joints
-    addJointData("home", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.1);
+    // Test Points & Joints: 
+    addMoveToPointData("homePoint", 
+        0.46200, 0.00000, 0.50500, 0.70711, 0.70711, 0.00000, 0.00000
+    );
+    addMoveToPointData("pointA", 
+        0.58638, 0.00000, 0.50499, 0.70711, 0.70711, 0.00000, 0.00000
+    );
+    addMoveToJointData("jointS", 
+        10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.1
+    );
 
-    /*Plate pick and place from hotel: hotel_nbr = 1, slot_hotel_nbr = 1 as base*/
-    // Flat manipulator
-    addJointData("point1", 0.0, 0.0, 0.0, 0.0, flat_man_ang, 0.0, 0.2, 0.1);
+    // Configuration Points & Joints:
+    addMoveToJointData("home", 
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.1
+    );
+
+    // Plate pick and place from hotel: hotel_number = 1, slot_hotel_number = 1 as base
+    // Flat manipulator position
+    addMoveToJointData("point1", 
+        0.0, 0.0, 0.0, 0.0, flat_manipulator_angle, 0.0, 0.2, 0.1
+    );
     // Facing plate hotel
-    addJointData("point2", init_arc_hotel - arc_hotel_disp, 0.0, 0.0, 0.0, flat_man_ang, 0.0, 0.2, 0.1);
+    addMoveToJointData("point2", 
+        initial_arc_hotel - arc_hotel_displacement, 0.0, 0.0, 0.0, 
+        flat_manipulator_angle, 0.0, 0.2, 0.1
+    );
     // Below plate level
-    addPointData("point3",  0.20225, -0.31025,  base_z + z_disp,  0.91163,  0.27090, -0.08805, -0.29630, 0.20000,  0.10000); // quaternion problem with generalizing on hotels
+    addMoveToPointData("point3",  
+        0.20225, -0.31025, base_z_position + z_displacement, 
+        0.91163, 0.27090, -0.08805, -0.29630, 0.20000, 0.10000
+    ); 
     // Forward - below plate
-    addPointData("point4",  0.24286, -0.37257,  base_z + z_disp,  0.91162,  0.27089, -0.08809, -0.29633, 0.05000,  0.10000); // we just want the same point 2 queternion
+    addMoveToPointData("point4",  
+        0.24286, -0.37257, base_z_position + z_displacement, 
+        0.91162, 0.27089, -0.08809, -0.29633, 0.05000, 0.10000
+    );
     // Pick up plate
-    addPointData("point5",  0.24286, -0.37257,  0.40110 + z_disp,  0.91163,  0.27089, -0.08805, -0.29631, 0.05000,  0.10000);
+    addMoveToPointData("point5",  
+        0.24286, -0.37257, 0.40110 + z_displacement, 
+        0.91163, 0.27089, -0.08805, -0.29631, 0.05000, 0.10000
+    );
     // Retrieve plate
-    addPointData("point6",  0.17422, -0.26728,  0.40110 + z_disp,  0.91162,  0.27087, -0.08806, -0.29635, 0.20000,  0.10000);
+    addMoveToPointData("point6",  
+        0.17422, -0.26728, 0.40110 + z_displacement, 
+        0.91162, 0.27087, -0.08806, -0.29635, 0.20000, 0.10000
+    );
     // Center robot
-    addPointData("point7",  0.31905,  0.00000,  0.40110 + z_disp,  0.67248,  0.67246, -0.21860, -0.21860, 0.10000,  0.10000);
-    // Place plate on workstation ...
+    addMoveToPointData("point7",  
+        0.31905, 0.00000, 0.40110 + z_displacement, 
+        0.67248, 0.67246, -0.21860, -0.21860, 0.10000, 0.10000
+    );
 
-    /*Plate pick and place from workstation: slot 1 as base*/
-
-    addTaskData("home", { 
-        "home" 
-    });
-    addTaskData("pointA", { 
-        "pointA" 
-    });
-    addTaskData("point1", { 
-        "point1" 
-    });
-    addTaskData("point2", { 
-        "point2" 
-    });
-    addTaskData("point3", { 
-        "point3" 
-    });
-    addTaskData("point4", { 
-        "point4" 
-    });
-    addTaskData("point5", { 
-        "point5" 
-    });
-    addTaskData("point6", { 
-        "point6" 
-    });
-    addTaskData("point7", { 
-        "point7" 
-    });
-    addTaskData("jointS", { 
-        "jointS" 
-    });
-    addTaskData("pickUpPlate", {
-        "home",
-        "point1",
-        "point2",
-        "point3",
-        "point4",
-        "point5",
-        "point6",
-        "point7",
-        "home"
-    });
-
+    addTaskData("home", { "home" });
+    addTaskData("pointA", { "pointA" });
+    addTaskData("point1", { "point1" });
+    addTaskData("point2", { "point2" });
+    addTaskData("point3", { "point3" });
+    addTaskData("point4", { "point4" });
+    addTaskData("point5", { "point5" });
+    addTaskData("point6", { "point6" });
+    addTaskData("point7", { "point7" });
+    addTaskData("jointS", { "jointS" });
+    addTaskData("pickUpPlate", 
+        { "home", "point1", "point2", "point3", "point4", "point5", "point6", "point7", "home" }
+    );
 }
 
 moveit::task_constructor::Task TaskFactory::createTask(const std::string& command) 
@@ -163,16 +164,16 @@ moveit::task_constructor::Task TaskFactory::createTask(const std::string& comman
     for (const auto& stage_ptr : task_data.stages) {
         std::string stage_name = "stage_" + std::to_string(stage_counter++);
         switch (stage_ptr->getType()) {
-            case StageType::JOINT:
+            case StageType::MOVE_TO_JOINT:
                 {
-                    auto joint_data = std::static_pointer_cast<JointData>(stage_ptr);
-                    addJointStage(current_task, stage_name + "_joint_move", joint_data);
+                    auto move_to_joint_data = std::static_pointer_cast<MoveToJointData>(stage_ptr);
+                    addMoveToJointStage(current_task, stage_name + "_joint_move", move_to_joint_data);
                     break;
                 }
-            case StageType::MOVE_TO:
+            case StageType::MOVE_TO_POINT:
                 {
-                    auto move_to_data = std::static_pointer_cast<MoveToData>(stage_ptr);
-                    addMoveToStage(current_task, stage_name + "_pose_move", move_to_data);
+                    auto move_to_point_data = std::static_pointer_cast<MoveToPointData>(stage_ptr);
+                    addMoveToPointStage(current_task, stage_name + "_pose_move", move_to_point_data);
                     break;
                 }
             default:
@@ -185,15 +186,15 @@ moveit::task_constructor::Task TaskFactory::createTask(const std::string& comman
     return current_task;
 }
 
-void TaskFactory::addJointStage(Task& task, const std::string& name, 
-                                const std::shared_ptr<JointData>& joint_data) 
+void TaskFactory::addMoveToJointStage(Task& task, const std::string& name, 
+                                      const std::shared_ptr<MoveToJointData>& move_to_joint_data) 
 {
     auto joint_interpolation_planner = std::make_shared<JointInterpolationPlanner>();
-    joint_interpolation_planner->setMaxVelocityScalingFactor(joint_data->velocity_scaling_factor);
-    joint_interpolation_planner->setMaxAccelerationScalingFactor(joint_data->acceleration_scaling_factor);
+    joint_interpolation_planner->setMaxVelocityScalingFactor(move_to_joint_data->velocity_scaling_factor);
+    joint_interpolation_planner->setMaxAccelerationScalingFactor(move_to_joint_data->acceleration_scaling_factor);
     
     auto current_stage = std::make_unique<MoveToStage>(name, joint_interpolation_planner);
-    current_stage->setGoal(joint_data->joint_positions);
+    current_stage->setGoal(move_to_joint_data->joint_positions);
     current_stage->setGroup("gp4_arm");
     current_stage->setIKFrame("eoat_tcp");
 
@@ -204,30 +205,30 @@ void TaskFactory::addJointStage(Task& task, const std::string& name,
 
     if (!current_stage) {
         throw StageCreationFailedException(
-            "TaskFactory::addJointStage failed to create stage: " + name
+            "TaskFactory::addMoveToJointStage failed to create stage: " + name
         );
     }
 
     task.add(std::move(current_stage));
 }
 
-void TaskFactory::addMoveToStage(Task& task, const std::string& name, 
-                                 const std::shared_ptr<MoveToData>& move_to_data) 
+void TaskFactory::addMoveToPointStage(Task& task, const std::string& name, 
+                                      const std::shared_ptr<MoveToPointData>& move_to_point_data) 
 {
     geometry_msgs::msg::PoseStamped target_pose;
     target_pose.header.frame_id = "base_link";
     target_pose.header.stamp = worm_picker_node_->now();
-    target_pose.pose.position.x = move_to_data->x;
-    target_pose.pose.position.y = move_to_data->y;
-    target_pose.pose.position.z = move_to_data->z;
-    target_pose.pose.orientation.x = move_to_data->qx;
-    target_pose.pose.orientation.y = move_to_data->qy;
-    target_pose.pose.orientation.z = move_to_data->qz;
-    target_pose.pose.orientation.w = move_to_data->qw;
+    target_pose.pose.position.x = move_to_point_data->x;
+    target_pose.pose.position.y = move_to_point_data->y;
+    target_pose.pose.position.z = move_to_point_data->z;
+    target_pose.pose.orientation.x = move_to_point_data->qx;
+    target_pose.pose.orientation.y = move_to_point_data->qy;
+    target_pose.pose.orientation.z = move_to_point_data->qz;
+    target_pose.pose.orientation.w = move_to_point_data->qw;
     
     auto cartesian_planner = std::make_shared<CartesianPath>();
-    cartesian_planner->setMaxVelocityScalingFactor(move_to_data->velocity_scaling_factor);
-    cartesian_planner->setMaxAccelerationScalingFactor(move_to_data->acceleration_scaling_factor);
+    cartesian_planner->setMaxVelocityScalingFactor(move_to_point_data->velocity_scaling_factor);
+    cartesian_planner->setMaxAccelerationScalingFactor(move_to_point_data->acceleration_scaling_factor);
     cartesian_planner->setStepSize(.01);
     cartesian_planner->setMinFraction(0.0);
 
@@ -243,7 +244,7 @@ void TaskFactory::addMoveToStage(Task& task, const std::string& name,
 
     if (!current_stage) {
         throw StageCreationFailedException(
-            "TaskFactory::addMoveToStage failed to create stage: " + name
+            "TaskFactory::addMoveToPointStage failed to create stage: " + name
         );
     }
 

--- a/worm_picker_core/src/tasks/task_factory.cpp
+++ b/worm_picker_core/src/tasks/task_factory.cpp
@@ -25,7 +25,7 @@ void TaskFactory::parseData()
 {
     const std::string input_directory = "/worm_picker_description/program_data/data_files/workstation_data.json";
 
-    WorkstationDataParser parser(input_directory, worm_picker_node_);
+    WorkstationDataParser parser(input_directory);
     workstation_data_map_ = parser.getWorkstationDataMap();
 }
 

--- a/worm_picker_description/program_data/data_files/workstation_data.json
+++ b/worm_picker_description/program_data/data_files/workstation_data.json
@@ -11,14 +11,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -30,14 +22,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -54,14 +38,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -73,14 +49,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -97,14 +65,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -116,14 +76,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -135,14 +87,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -159,14 +103,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -178,14 +114,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -197,14 +125,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -221,14 +141,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -240,14 +152,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -259,14 +163,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "4": {
@@ -278,14 +174,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -302,14 +190,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -321,14 +201,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -340,14 +212,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -364,14 +228,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -383,14 +239,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -402,14 +250,6 @@
                     "orientation_y": 0.00086,
                     "orientation_z": 0.71210,
                     "orientation_w": -0.00096
-                },
-                "joint": {
-                    "joint_1": 0.000,
-                    "joint_2": 28.485,
-                    "joint_3": 9.713,
-                    "joint_4": 0.000,
-                    "joint_5": -10.416,
-                    "joint_6": 0.000
                 }
             },
             "4": {
@@ -421,14 +261,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -445,14 +277,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -464,14 +288,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -483,14 +299,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -507,14 +315,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -526,14 +326,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -545,14 +337,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "4": {
@@ -564,14 +348,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -588,14 +364,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -607,14 +375,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "3": {
@@ -626,14 +386,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -650,14 +402,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -669,14 +413,6 @@
                     "orientation_y": 0.19764,
                     "orientation_z": 0.68346,
                     "orientation_w": -0.20057
-                },
-                "joint": {
-                    "joint_1": 32.559,
-                    "joint_2": 5.219,
-                    "joint_3": -19.471,
-                    "joint_4": 0.000,
-                    "joint_5": -4.471,
-                    "joint_6": 0.000
                 }
             },
             "3": {
@@ -688,14 +424,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -712,14 +440,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -731,14 +451,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }
@@ -755,14 +467,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             },
             "2": {
@@ -774,14 +478,6 @@
                     "orientation_y": -9999.9,
                     "orientation_z": -9999.9,
                     "orientation_w": -9999.9
-                },
-                "joint": {
-                    "joint_1": -9999.9,
-                    "joint_2": -9999.9,
-                    "joint_3": -9999.9,
-                    "joint_4": -9999.9,
-                    "joint_5": -9999.9,
-                    "joint_6": -9999.9
                 }
             }
         }


### PR DESCRIPTION
This PR refactors the `worm_picker_core` codebase for improved clarity and maintainability. Key changes:

- **Renamed Structs**:
  - `MoveToData` → `MoveToPointData` (for point-based movement).
  - `JointData` → `MoveToJointData` (for joint-based movement).
  
- **Updated Enums**:
  - `StageType::MOVE_TO` → `StageType::MOVE_TO_POINT`.
  - `StageType::JOINT` → `StageType::MOVE_TO_JOINT`.

- **TaskFactory Methods**:
  - Refactored to use `MoveToPointData` and `MoveToJointData`.
  - Error handling and task creation updated to match new names.

- **Removed Joint Data**:
  - Removed `Joint` struct and associated data from `WorkstationData`.
  - Simplified `WorkstationDataParser` to handle only coordinate data.

- **Additional Changes**:
  - Updated comments and documentation to reflect name changes.
  - Simplified joint data parsing logic.

This refactor enhances readability and streamlines future development for movement stages in WormPicker.