### PR TITLE
chore: replace header guards with #pragma once

### DIFF
--- a/worm_picker_core/include/worm_picker_core/core/commands/command_config.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/commands/command_config.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef COMMAND_CONFIG_HPP
-#define COMMAND_CONFIG_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include "worm_picker_core/utils/parameter_utils.hpp"
@@ -51,5 +50,3 @@ public:
 private:
     StringVec argument_names_{};
 };
-
-#endif // COMMAND_CONFIG_HPP

--- a/worm_picker_core/include/worm_picker_core/core/commands/command_info.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/commands/command_info.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef COMMAND_INFO_HPP
-#define COMMAND_INFO_HPP
+#pragma once
 
 #include <string>
 #include <vector>
@@ -36,5 +35,3 @@ private:
     SpeedOverrideOpt speed_override_{};
     size_t base_args_amount_{0};
 };
-
-#endif // COMMAND_INFO_HPP

--- a/worm_picker_core/include/worm_picker_core/core/geometry/coordinate.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/geometry/coordinate.hpp
@@ -1,10 +1,9 @@
 // coordinate.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef COORDINATE_HPP
-#define COORDINATE_HPP
+#pragma once
 
 class Coordinate {
 public:
@@ -40,5 +39,3 @@ private:
     double orientation_z_{}; 
     double orientation_w_{};
 };
-
-#endif // COORDINATE_HPP

--- a/worm_picker_core/include/worm_picker_core/core/geometry/fixed_point.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/geometry/fixed_point.hpp
@@ -1,10 +1,9 @@
 // fixed_point.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef FIXED_POINT_HPP
-#define FIXED_POINT_HPP
+#pragma once
 
 #include <string>
 
@@ -28,5 +27,3 @@ private:
     double x_{};
     double y_{};
 };
-
-#endif // FIXED_POINT_HPP

--- a/worm_picker_core/include/worm_picker_core/core/geometry/workstation_geometry.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/geometry/workstation_geometry.hpp
@@ -1,10 +1,9 @@
 // workstation_geometry.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORKSTATION_GEOMETRY_HPP
-#define WORKSTATION_GEOMETRY_HPP
+#pragma once
 
 #include <vector>
 #include "worm_picker_core/core/geometry/fixed_point.hpp"
@@ -28,5 +27,3 @@ private:
     double ray_separation_angle_{};
     std::vector<FixedPoint> fixed_points_{};
 };
-
-#endif // WORKSTATION_GEOMETRY_HPP

--- a/worm_picker_core/include/worm_picker_core/core/model/hotel_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/model/hotel_data.hpp
@@ -1,10 +1,9 @@
 // hotel_data.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef HOTEL_DATA_HPP
-#define HOTEL_DATA_HPP
+#pragma once
 
 #include "worm_picker_core/core/geometry/coordinate.hpp"
 
@@ -21,5 +20,3 @@ public:
 private:
     Coordinate coordinate_{};
 };
-
-#endif // HOTEL_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/core/model/workstation_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/model/workstation_data.hpp
@@ -1,10 +1,9 @@
 // workstation_data.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORKSTATION_DATA_HPP
-#define WORKSTATION_DATA_HPP
+#pragma once
 
 #include "worm_picker_core/core/geometry/coordinate.hpp"
 
@@ -21,5 +20,3 @@ public:
 private:
     Coordinate coordinate_{};
 };
-
-#endif // WORKSTATION_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/planner_factory.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/planner_factory.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef PLANNER_FACTORY_HPP
-#define PLANNER_FACTORY_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <moveit/task_constructor/solvers.h>
@@ -32,5 +31,3 @@ private:
 
     std::map<std::string, CreatorFunc> planner_creators_;
 };
-
-#endif // PLANNER_FACTORY_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/stage_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/stage_data.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef STAGE_DATA_HPP
-#define STAGE_DATA_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <moveit/task_constructor/stage.h>
@@ -35,5 +34,3 @@ inline const std::unordered_map<StageType, std::string> StageData::type_map_ = {
     {StageType::MOVE_TO_JOINT, "move_to_joint"},
     {StageType::MOVE_RELATIVE, "move_relative"}
 };
-
-#endif // STAGE_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/stages/move_relative_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/stages/move_relative_data.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef MOVE_RELATIVE_DATA_HPP
-#define MOVE_RELATIVE_DATA_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/stages/movement_data_base.hpp"
 
@@ -30,5 +29,3 @@ private:
     double dy_{};
     double dz_{};
 };
-
-#endif // MOVE_RELATIVE_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/stages/move_to_joint_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/stages/move_to_joint_data.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef MOVE_TO_JOINT_DATA_HPP
-#define MOVE_TO_JOINT_DATA_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/stages/movement_data_base.hpp"
 
@@ -30,5 +29,3 @@ private:
     static constexpr double DEG_TO_RAD = 3.14159265358979323846 / 180.0;
     std::map<std::string, double> joint_positions_{};
 };
-
-#endif // MOVE_TO_JOINT_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/stages/move_to_point_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/stages/move_to_point_data.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef MOVE_TO_POINT_DATA_HPP
-#define MOVE_TO_POINT_DATA_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/stages/movement_data_base.hpp"
 
@@ -39,5 +38,3 @@ private:
     double qz_{};
     double qw_{};
 };
-
-#endif // MOVE_TO_POINT_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/stages/movement_data_base.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/stages/movement_data_base.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef MOVEMENT_DATA_BASE_HPP
-#define MOVEMENT_DATA_BASE_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/stage_data.hpp"
 
@@ -36,5 +35,3 @@ private:
     double velocity_scaling_;
     double acceleration_scaling_;
 };
-
-#endif // MOVEMENT_DATA_BASE_HPP

--- a/worm_picker_core/include/worm_picker_core/core/tasks/task_data.hpp
+++ b/worm_picker_core/include/worm_picker_core/core/tasks/task_data.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TASK_DATA_HPP
-#define TASK_DATA_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/stage_data.hpp"
 
@@ -25,5 +24,3 @@ public:
 private:
     StageVector stages_{};
 };
-
-#endif // TASK_DATA_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/interface/cli/cal_command_interface.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/interface/cli/cal_command_interface.hpp
@@ -1,10 +1,9 @@
 // cal_command_interface.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef CAL_COMMAND_INTERFACE_HPP
-#define CAL_COMMAND_INTERFACE_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <worm_picker_custom_msgs/srv/calibration_command.hpp>
@@ -24,5 +23,3 @@ private:
     rclcpp::Node::SharedPtr node_;
     rclcpp::Client<CalibrationCommand>::SharedPtr client_;
 };
-
-#endif // CAL_COMMAND_INTERFACE_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/interface/cli/core_command_interface.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/interface/cli/core_command_interface.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef CORE_COMMAND_INTERFACE_HPP
-#define CORE_COMMAND_INTERFACE_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <worm_picker_custom_msgs/srv/task_command.hpp>
@@ -46,5 +45,3 @@ private:
 };
 
 } // namespace worm_picker
-
-#endif // CORE_COMMAND_INTERFACE_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/interface/network/ros_command_client.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/interface/network/ros_command_client.hpp
@@ -1,10 +1,9 @@
 // ros_command_client.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ROS_COMMAND_CLIENT_HPP
-#define ROS_COMMAND_CLIENT_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp> 
 #include <worm_picker_custom_msgs/srv/task_command.hpp> 
@@ -35,5 +34,3 @@ private:
     rclcpp::Client<Trigger>::SharedPtr stop_traj_client_;
     std::unordered_map<std::string, std::function<void(StatusCallback)>> command_handlers_;
 };
-
-#endif // ROS_COMMAND_CLIENT_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/interface/network/tcp_socket_server.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/interface/network/tcp_socket_server.hpp
@@ -1,10 +1,9 @@
 // tcp_socket_server.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TCP_SOCKET_SERVER_HPP
-#define TCP_SOCKET_SERVER_HPP
+#pragma once
 
 #include <netinet/in.h>
 #include <unistd.h>
@@ -110,5 +109,3 @@ private:
     CommandHandler command_handler_;  // The handler function for processing received commands.
     std::mutex command_handler_mutex_;  // Mutex for synchronizing access to the command handler.
 };
-
-#endif // TCP_SOCKET_SERVER_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/parsers/calibration_points_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/parsers/calibration_points_parser.hpp
@@ -1,10 +1,9 @@
 // calibration_points_parser.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef CALIBRATION_POINTS_PARSER_HPP
-#define CALIBRATION_POINTS_PARSER_HPP
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include "worm_picker_core/core/tasks/stages/move_to_joint_data.hpp"
@@ -25,5 +24,3 @@ private:
     PointMap point_map_;
     std::vector<std::string> point_order_;
 };
-
-#endif // CALIBRATION_POINTS_PARSER_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/parsers/command_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/parsers/command_parser.hpp
@@ -1,10 +1,9 @@
 // command_parser.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef COMMAND_PARSER_HPP
-#define COMMAND_PARSER_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include "worm_picker_core/core/result.hpp"
@@ -32,5 +31,3 @@ private:
 
     CommandConfigVec configs_;
 };
-
-#endif // COMMAND_PARSER_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/parsers/defined_tasks_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/parsers/defined_tasks_parser.hpp
@@ -1,10 +1,9 @@
 // defined_tasks_parser.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef DEFINED_TASKS_PARSER_HPP
-#define DEFINED_TASKS_PARSER_HPP
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include "worm_picker_core/core/tasks/task_data.hpp"
@@ -34,5 +33,3 @@ private:
     std::string tasks_file_;
     TaskDataMap task_data_map_;
 };
-
-#endif // DEFINED_TASKS_PARSER_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/parsers/hotel_data_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/parsers/hotel_data_parser.hpp
@@ -1,10 +1,9 @@
 // hotel_data_parser.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef HOTEL_DATA_PARSER_HPP
-#define HOTEL_DATA_PARSER_HPP
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include "worm_picker_core/core/model/hotel_data.hpp"
@@ -19,5 +18,3 @@ public:
 private:
     HotelDataMap hotel_data_map_;
 };
-
-#endif // HOTEL_DATA_PARSER_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/parsers/workstation_data_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/parsers/workstation_data_parser.hpp
@@ -1,10 +1,9 @@
 // workstation_data_parser.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORKSTATION_DATA_PARSER_HPP
-#define WORKSTATION_DATA_PARSER_HPP
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include "worm_picker_core/core/model/workstation_data.hpp"
@@ -26,5 +25,3 @@ private:
     static constexpr double INVALID_VALUE = -9999.9;
     WorkstationDataMap workstation_data_map_;
 };
-
-#endif // WORKSTATION_DATA_PARSER_HPP

--- a/worm_picker_core/include/worm_picker_core/infrastructure/parsers/workstation_geometry_parser.hpp
+++ b/worm_picker_core/include/worm_picker_core/infrastructure/parsers/workstation_geometry_parser.hpp
@@ -1,10 +1,9 @@
 // workstation_geometry_parser.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORKSTATION_GEOMETRY_PARSER_HPP
-#define WORKSTATION_GEOMETRY_PARSER_HPP
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include "worm_picker_core/core/geometry/fixed_point.hpp"
@@ -22,5 +21,3 @@ private:
 
     WorkstationGeometry geometry_;
 };
-
-#endif // WORKSTATION_GEOMETRY_PARSER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/calibration/calibration_state_machine.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/calibration/calibration_state_machine.hpp
@@ -1,10 +1,9 @@
 // calibrations_state_machine.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef CALIBRATION_STATE_MACHINE_HPP
-#define CALIBRATION_STATE_MACHINE_HPP
+#pragma once
 
 #include <fmt/format.h>
 #include <rclcpp/rclcpp.hpp>
@@ -84,5 +83,3 @@ private:
     std::map<std::string, Pose> recorded_positions_;
     const CommandHandlerMap command_handlers_;
 };
-
-#endif // CALIBRATION_STATE_MACHINE_HPP

--- a/worm_picker_core/include/worm_picker_core/system/calibration/plate_position_analyzer.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/calibration/plate_position_analyzer.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef PLATE_POSITION_ANALYZER_HPP
-#define PLATE_POSITION_ANALYZER_HPP
+#pragma once
 
 #include <map>
 // #include <string>
@@ -82,5 +81,3 @@ struct Quaternion {
         return Quaternion{-x, -y, -z, w};
     }
 };
-
-#endif // PLATE_POSITION_ANALYZER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/calibration/robot_controller.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/calibration/robot_controller.hpp
@@ -1,10 +1,9 @@
 // robot_controller.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ROBOT_CONTROLLER_HPP
-#define ROBOT_CONTROLLER_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -48,5 +47,3 @@ private:
     std::shared_ptr<planning_scene::PlanningScene> current_scene_;
     mutable std::mutex scene_mutex_;
 };
-
-#endif // ROBOT_CONTROLLER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/calibration/workstation_json_generator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/calibration/workstation_json_generator.hpp
@@ -1,10 +1,9 @@
 // workstation_json_generator.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORKSTATION_JSON_GENERATOR_HPP
-#define WORKSTATION_JSON_GENERATOR_HPP
+#pragma once
 
 #include <nlohmann/json.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -29,5 +28,3 @@ private:
 
     const PoseMap& averaged_poses_;
 };
-
-#endif // WORKSTATION_JSON_GENERATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/system/management/action_client_manager.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/management/action_client_manager.hpp
@@ -1,10 +1,9 @@
 // action_client_manager.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ACTION_CLIENT_MANAGER_HPP
-#define ACTION_CLIENT_MANAGER_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
@@ -31,5 +30,3 @@ private:
     std::jthread wait_thread_;
     AtomicBool server_available_;
 };
-
-#endif // ACTION_CLIENT_MANAGER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/management/parameter_manager.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/management/parameter_manager.hpp
@@ -1,10 +1,9 @@
 // parameter_manager.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef PARAMETER_MANAGER_HPP
-#define PARAMETER_MANAGER_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <yaml-cpp/yaml.h>
@@ -53,5 +52,3 @@ inline bool ParameterManager::tryDeclareParam<std::vector<std::string>>(
         return false;
     }
 }
-
-#endif // PARAMETER_MANAGER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/management/service_handler.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/management/service_handler.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SERVICE_HANDLER_HPP
-#define SERVICE_HANDLER_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -37,5 +36,3 @@ private:
     TaskManagerPtr task_manager_;
     ActionClientManagerPtr action_client_manager_;
 };
-
-#endif // SERVICE_HANDLER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/nodes/plate_calibration.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/nodes/plate_calibration.hpp
@@ -1,10 +1,9 @@
 // plate_calibration.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef PLATE_CALIBRATION_HPP
-#define PLATE_CALIBRATION_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
@@ -41,5 +40,3 @@ private:
     std::shared_ptr<RobotController> robot_controller_;
     std::jthread server_wait_thread_;
 };
-
-#endif // PLATE_CALIBRATION_HPP

--- a/worm_picker_core/include/worm_picker_core/system/nodes/worm_picker_controller.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/nodes/worm_picker_controller.hpp
@@ -1,10 +1,9 @@
 // worm_picker_controller.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORM_PICKER_CONTROLLER_HPP
-#define WORM_PICKER_CONTROLLER_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include "worm_picker_core/system/tasks/task_factory.hpp"
@@ -53,5 +52,3 @@ private:
     TaskManagerPtr task_manager_;
     TimerDataCollectorPtr timer_data_collector_;
 };
-
-#endif // WORM_PICKER_CONTROLLER_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/generation/base_task_generator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/generation/base_task_generator.hpp
@@ -1,10 +1,9 @@
 // base_task_generator.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef BASE_TASK_GENERATOR_HPP
-#define BASE_TASK_GENERATOR_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/task_data.hpp"
 
@@ -25,5 +24,3 @@ protected:
 
     std::unordered_map<std::string, TaskData> task_data_map_;
 };
-
-#endif // BASE_TASK_GENERATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/generation/generate_hotel_task_generator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/generation/generate_hotel_task_generator.hpp
@@ -1,10 +1,9 @@
 // generate_hotel_task_generator.hpp
 //
-// Copyright (c)
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef GENERATE_HOTEL_TASK_GENERATOR_HPP
-#define GENERATE_HOTEL_TASK_GENERATOR_HPP
+#pragma once
 
 #include "worm_picker_core/system/tasks/generation/generic_task_generator.hpp"
 #include "worm_picker_core/core/geometry/coordinate.hpp"
@@ -35,5 +34,3 @@ private:
 
     TaskType task_type_;
 };
-
-#endif // GENERATE_HOTEL_TASK_GENERATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/generation/generate_relative_movement_task.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/generation/generate_relative_movement_task.hpp
@@ -1,22 +1,20 @@
 // generate_relative_movement_task.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef GENERATE_RELATIVE_MOVEMENT_TASK_HPP
-#define GENERATE_RELATIVE_MOVEMENT_TASK_HPP
+#pragma once
 
+#include "worm_picker_core/core/result.hpp"
 #include "worm_picker_core/core/tasks/task_data.hpp"
 
 class GenerateRelativeMovementTask {
 public:
-    static TaskData parseCommand(const std::vector<std::string>& args);
+    static Result<TaskData> parseCommand(const std::vector<std::string>& args);
 
 private:
     using CoordinateTuple = std::tuple<double, double, double>;
     
-    static CoordinateTuple extractCoordinates(const std::vector<std::string>& args);
-    static double parseDouble(const std::string& value);
+    static Result<CoordinateTuple> extractCoordinates(const std::vector<std::string>& args);
+    static Result<double> parseDouble(const std::string& value);
 };
-
-#endif // GENERATE_RELATIVE_MOVEMENT_TASK_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/generation/generate_workstation_task_generator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/generation/generate_workstation_task_generator.hpp
@@ -1,10 +1,9 @@
 // generate_workstation_task_generator.hpp
 //
-// Copyright (c)
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef GENERATE_WORKSTATION_TASK_GENERATOR_HPP
-#define GENERATE_WORKSTATION_TASK_GENERATOR_HPP
+#pragma once
 
 #include "worm_picker_core/system/tasks/generation/generic_task_generator.hpp"
 #include "worm_picker_core/core/geometry/coordinate.hpp"
@@ -59,5 +58,3 @@ private:
     /// @brief Type of task this generator is configured to create
     TaskType task_type_;
 };
-
-#endif // GENERATE_WORKSTATION_TASK_GENERATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/generation/generic_task_generator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/generation/generic_task_generator.hpp
@@ -1,10 +1,9 @@
 // generic_task_generator.hpp
 //
-// Copyright (c)
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef GENERIC_TASK_GENERATOR_HPP
-#define GENERIC_TASK_GENERATOR_HPP
+#pragma once
 
 #include "worm_picker_core/system/tasks/generation/base_task_generator.hpp"
 
@@ -38,5 +37,3 @@ protected:
 
     const std::unordered_map<std::string, DataType>& data_map_;
 };
-
-#endif // GENERIC_TASK_GENERATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/generation/workstation_task_config.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/generation/workstation_task_config.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef WORKSTATION_TASK_CONFIG_HPP
-#define WORKSTATION_TASK_CONFIG_HPP
+#pragma once
 
 /// @brief Configuration namespace for workstation task generation parameters and constants
 namespace workstation_config {
@@ -53,5 +52,3 @@ namespace angle {
 }
 
 } // namespace workstation_config
-
-#endif // WORKSTATION_TASK_CONFIG_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/task_factory.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/task_factory.hpp
@@ -1,10 +1,9 @@
 // task_factory.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TASK_FACTORY_HPP
-#define TASK_FACTORY_HPP
+#pragma once
 
 #include <fmt/format.h>
 #include <rclcpp/rclcpp.hpp>
@@ -49,5 +48,3 @@ private:
     std::unique_ptr<CommandParser> command_parser_;
     TaskDataMap task_data_map_;
 };
-
-#endif // TASK_FACTORY_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/task_generator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/task_generator.hpp
@@ -1,10 +1,9 @@
 // task_generator.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TASK_GENERATOR_HPP
-#define TASK_GENERATOR_HPP
+#pragma once
 
 #include "worm_picker_core/core/tasks/task_data.hpp"
 #include "worm_picker_core/system/tasks/generation/generate_workstation_task_generator.hpp"
@@ -51,5 +50,3 @@ private:
     /// @brief 
     TaskMap task_data_map_;
 };
-
-#endif // TASK_GENERATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/system/tasks/task_validator.hpp
+++ b/worm_picker_core/include/worm_picker_core/system/tasks/task_validator.hpp
@@ -1,10 +1,9 @@
 // task_validator.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TASK_VALIDATOR_HPP
-#define TASK_VALIDATOR_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 #include <moveit/task_constructor/task.h>
@@ -45,5 +44,3 @@ private:
     double orientation_tolerance_;
     double joint_tolerance_;
 };
-
-#endif // TASK_VALIDATOR_HPP

--- a/worm_picker_core/include/worm_picker_core/utils/execution_timer.hpp
+++ b/worm_picker_core/include/worm_picker_core/utils/execution_timer.hpp
@@ -1,10 +1,9 @@
 // execution_timer.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef EXECUTION_TIMER_HPP
-#define EXECUTION_TIMER_HPP
+#pragma once
 
 #include <string>
 #include <chrono>
@@ -24,6 +23,3 @@ private:
     std::string timer_name_;
     std::chrono::time_point<std::chrono::steady_clock> start_time_;
 };
-
-#endif // EXECUTION_TIMER_HPP
-

--- a/worm_picker_core/include/worm_picker_core/utils/parameter_utils.hpp
+++ b/worm_picker_core/include/worm_picker_core/utils/parameter_utils.hpp
@@ -1,10 +1,9 @@
 // parameter_utils.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef PARAMETER_UTILS_HPP
-#define PARAMETER_UTILS_HPP
+#pragma once
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -43,5 +42,3 @@ bool setParameter(const rclcpp::Node::SharedPtr& node, const std::string& name, 
 }
 
 } // namespace param_utils
-
-#endif // PARAMETER_UTILS_HPP

--- a/worm_picker_core/include/worm_picker_core/utils/scoped_timer.hpp
+++ b/worm_picker_core/include/worm_picker_core/utils/scoped_timer.hpp
@@ -3,8 +3,7 @@
 // Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef SCOPED_TIMER_HPP
-#define SCOPED_TIMER_HPP
+#pragma once
 
 #include <vector>
 #include "worm_picker_core/utils/execution_timer.hpp"
@@ -20,5 +19,3 @@ private:
     TimerResults& results_;
     ExecutionTimer timer_;
 };
-
-#endif // SCOPED_TIMER_HPP

--- a/worm_picker_core/include/worm_picker_core/utils/timer_data_collector.hpp
+++ b/worm_picker_core/include/worm_picker_core/utils/timer_data_collector.hpp
@@ -1,10 +1,9 @@
 // timer_data_collector.hpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TIMER_DATA_COLLECTOR_HPP
-#define TIMER_DATA_COLLECTOR_HPP
+#pragma once
 
 #include <filesystem>
 #include <nlohmann/json.hpp>
@@ -28,5 +27,3 @@ private:
     nlohmann::json data_;
     std::filesystem::path output_path_;
 };
-
-#endif  // TIMER_DATA_COLLECTOR_HPP

--- a/worm_picker_core/src/system/tasks/generation/generate_relative_movement_task.cpp
+++ b/worm_picker_core/src/system/tasks/generation/generate_relative_movement_task.cpp
@@ -1,37 +1,58 @@
 // generate_relative_movement_task.cpp
 //
-// Copyright (c) 2024
+// Copyright (c) 2025
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/format.h>
 #include "worm_picker_core/core/tasks/stages/move_relative_data.hpp"
 #include "worm_picker_core/system/tasks/generation/generate_relative_movement_task.hpp"
 
-TaskData GenerateRelativeMovementTask::parseCommand(const std::vector<std::string>& args) 
+Result<TaskData> GenerateRelativeMovementTask::parseCommand(const std::vector<std::string>& args) 
 {
-    auto [x, y, z] = extractCoordinates(args);
-    return TaskData{
-        std::vector<std::shared_ptr<StageData>>{
-            std::make_shared<MoveRelativeData>(x, y, z)
-        }
+    auto createMovementData = [](const CoordinateTuple& values) -> std::shared_ptr<StageData> {
+        auto [x, y, z] = values;
+        return std::make_shared<MoveRelativeData>(x, y, z);
     };
+    auto createTaskData = [](std::shared_ptr<StageData> movement_stage) -> TaskData {
+        return TaskData{std::vector<std::shared_ptr<StageData>>{movement_stage}};
+    };
+
+    return extractCoordinates(args)
+        .map(createMovementData)
+        .map(createTaskData);
 }
 
-GenerateRelativeMovementTask::CoordinateTuple
+Result<GenerateRelativeMovementTask::CoordinateTuple>
 GenerateRelativeMovementTask::extractCoordinates(const std::vector<std::string>& args) 
 {
     if (args.size() < 3) {
-        throw std::invalid_argument("Insufficient coordinates for relative movement");
+        return Result<CoordinateTuple>::error("Insufficient coordinates for relative movement");
     }
 
-    return {parseDouble(args[0]), parseDouble(args[1]), parseDouble(args[2])};
+    auto handleParseError = [](const std::string& value, const std::string& coordinateName) {
+        auto msg = fmt::format("Failed to parse {} coordinate: {}", coordinateName, value);
+        return Result<CoordinateTuple>::error(msg);
+    };
+
+    auto x_result = parseDouble(args[0]);
+    if (!x_result) return handleParseError(args[0], "X");
+
+    auto y_result = parseDouble(args[1]);
+    if (!y_result) return handleParseError(args[1], "Y");
+
+    auto z_result = parseDouble(args[2]);
+    if (!z_result) return handleParseError(args[2], "Z");
+
+    return Result<CoordinateTuple>::success(
+        std::make_tuple(x_result.value(), y_result.value(), z_result.value())
+    );
 }
 
-double GenerateRelativeMovementTask::parseDouble(const std::string& value) 
+Result<double> GenerateRelativeMovementTask::parseDouble(const std::string& value) 
 {
     try {
-        return std::stod(std::string(value));
+        return Result<double>::success(std::stod(std::string(value)));
     } catch (const std::exception&) {
-        throw std::invalid_argument(fmt::format("Invalid numeric value: {}", value));
+        return Result<double>::error(fmt::format("Invalid numeric value: {}", value));
     }
 }


### PR DESCRIPTION
This pull request includes multiple changes across various files in the `worm_picker_core` project. The primary focus of these changes is to replace include guards with `#pragma once` for improved code simplicity and consistency. Additionally, there are updates to copyright years.

Header guard replacements:

* [`worm_picker_core/include/worm_picker_core/core/commands/command_config.hpp`](diffhunk://#diff-f9b34cb296df516073b03354acb83ae69f8a81b86a897a0d81a3f277f42ca369L6-R6): Replaced header guards with `#pragma once`.
* [`worm_picker_core/include/worm_picker_core/core/commands/command_info.hpp`](diffhunk://#diff-3b6cb6d035d831b0d63b951b9d3be25379bebe508b9b46b935eeecf0d905249cL6-R6): Replaced header guards with `#pragma once`.
* [`worm_picker_core/include/worm_picker_core/core/geometry/coordinate.hpp`](diffhunk://#diff-50155b61447cc13f385293d1753c6d37a272e97673cfdc0f6b66db6dbd5bfe16L3-R6): Replaced header guards with `#pragma once`.
* [`worm_picker_core/include/worm_picker_core/core/geometry/fixed_point.hpp`](diffhunk://#diff-a09bf1070f7a6c76783150d09cc7c0f3258640a4d0d6716aba48d9437d3756acL3-R6): Replaced header guards with `#pragma once`.
* [`worm_picker_core/include/worm_picker_core/core/geometry/workstation_geometry.hpp`](diffhunk://#diff-fa705083c931b69db72327e8a3adf20ec632ee17a2a9ae4e6881c86e748e9739L3-R6): Replaced header guards with `#pragma once`.

Other changes:

* Updated copyright years from 2024 to 2025 in multiple files:
  - `worm_picker_core/include/worm_picker_core/core/geometry/coordinate.hpp`
  - `worm_picker_core/include/worm_picker_core/core/geometry/fixed_point.hpp`
  - `worm_picker_core/include/worm_picker_core/core/geometry/workstation_geometry.hpp`
  - `worm_picker_core/include/worm_picker_core/core/model/hotel_data.hpp`
  - `worm_picker_core/include/worm_picker_core/core/model/workstation_data.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/planner_factory.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/stage_data.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/stages/move_relative_data.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/stages/move_to_joint_data.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/stages/move_to_point_data.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/stages/movement_data_base.hpp`
  - `worm_picker_core/include/worm_picker_core/core/tasks/task_data.hpp`
  - `worm_picker_core/include/worm_picker_core/infrastructure/interface/cli/cal_command_interface.hpp`
  - `worm_picker_core/include/worm_picker_core/infrastructure/interface/cli/core_command_interface.hpp`
  - `worm_picker_core/include/worm_picker_core/infrastructure/interface/network/ros_command_client.hpp`
  - `worm_picker_core/include/worm_picker_core/infrastructure/interface/network/tcp_socket_server.hpp`
  - `worm_picker_core/include/worm_picker_core/infrastructure/parsers/calibration_points_parser.hpp`
  - `worm_picker_core/include/worm_picker_core/infrastructure/parsers/command_parser.hpp`